### PR TITLE
Obfuscated login responses from server

### DIFF
--- a/back/middlewares/user.js
+++ b/back/middlewares/user.js
@@ -55,9 +55,8 @@ const serviceCalls = {
 
       // handle known errors unknown user and incorrect password with a
       // response
-      if(e.name === 'Unknown user' || e.name === 'Incorrect password') {
+      if(e.name === 'Invalid credentials') {
         return response
-          //.set('WWW-Authenticate', 'Basic')
           .status(401)
           .send({
             error: e.message

--- a/back/services/user.js
+++ b/back/services/user.js
@@ -16,11 +16,11 @@ const service = {
   /**
    * Authenticate a user based on the credentials given.
    *
-   * @param {object} credentials - User's name and password hash.
+   * @param {object} credentials - User's name and password.
    * @return {Promise<number|undefined>} Authenticated user's id, undefined when unmatched
    *
    * @example
-   * service.authenticate({ name: 'Mark', pwhash: $2y$08$G1g... })
+   * service.authenticate({ name: 'Mark', password: 'mark_password' })
    */
   authenticate: async function authenticateUser(credentials) {
     const users = await models.user.read({

--- a/back/services/user.js
+++ b/back/services/user.js
@@ -16,11 +16,11 @@ const service = {
   /**
    * Authenticate a user based on the credentials given.
    *
-   * @param {object} credentials - User's name and password.
+   * @param {object} credentials - User's name and password hash.
    * @return {Promise<number|undefined>} Authenticated user's id, undefined when unmatched
    *
    * @example
-   * service.authenticate({ name: 'Mark', password: 'mark_password' })
+   * service.authenticate({ name: 'Mark', pwhash: $2y$08$G1g... })
    */
   authenticate: async function authenticateUser(credentials) {
     const users = await models.user.read({
@@ -28,8 +28,8 @@ const service = {
     }, ['id', 'digest']);
 
     if(users.length === 0) {
-      const err = Error('Username didn\'t match any users');
-      err.name = 'Unknown user';
+      const err = Error('Invalid credentials');
+      err.name = 'Invalid credentials';
       throw err;
     }
 
@@ -39,8 +39,8 @@ const service = {
       .compare(credentials.password, user.digest.toString());
 
     if(passwordMatches === false) {
-      const err = Error('Password was incorrect');
-      err.name = 'Incorrect password';
+      const err = Error('Invalid credentials');
+      err.name = 'Invalid credentials';
       throw err;
     }
 


### PR DESCRIPTION
The original system seems good enough: it uses SSL and HTTPS to ensure that no MITM happens, and uses server-side hashing with bcrypt to check and save passwords to the database.

The only change for now was that the clientside will not be told what was wrong with the login attempt: it'll now only send back a response named "Invalid credentials".