### PR TITLE
Stats backend

### DIFF
--- a/back/controllers/daterange.js
+++ b/back/controllers/daterange.js
@@ -34,6 +34,7 @@ const controller = {
           short_description: instance['short_description'],
           trackSupervision: instance['track_supervisor'],
           scheduled: {
+            visitors: instance['visitors'],
             notice: instance['notice'],
             scheduled_range_supervision_id: instance['scheduled_range_supervision_id'],
             track_id: instance['track_id'],
@@ -52,6 +53,7 @@ const controller = {
         short_description: instance['short_description'],
         trackSupervision: instance['track_supervisor'],
         scheduled: {
+          visitors: instance['visitors'],
           notice: instance['notice'],
           scheduled_range_supervision_id: instance['scheduled_range_supervision_id'],
           track_id: instance['track_id'],

--- a/back/controllers/trackSupervision.js
+++ b/back/controllers/trackSupervision.js
@@ -25,7 +25,6 @@ const controller = {
       .send(response.locals.queryResult);
   },
 
-  // no returning response here?
   update: async function updateSupervision(request, response) {
     return response
       .status(204)

--- a/back/knex/development/migrations/20200227235307_create_track_supervision_table.js
+++ b/back/knex/development/migrations/20200227235307_create_track_supervision_table.js
@@ -10,6 +10,9 @@ exports.up = function(knex) {
         .references('id')
         .inTable('track')
         .notNullable();
+      supervision.integer('visitors')
+        .notNullable()
+        .defaultTo(0);
       supervision.timestamp('updated_at', { useTz: true, precision: 6 })
         .defaultTo(knex.fn.now())
         .notNullable();

--- a/back/knex/development/seeds/08_track_supervision.js
+++ b/back/knex/development/seeds/08_track_supervision.js
@@ -57,6 +57,7 @@ casual.define('track_supervision', async (trackId, supervisionId) => {
     scheduled_range_supervision_id: supervisionId,
     track_id: trackId,
     track_supervisor: state[casual.integer(0, state.length - 1)],
+    visitors: casual.integer(0, 1000),
     notice: casual.description.substring(0, 255)
   };
 });

--- a/back/knex/stable/seeds/08_track_supervision.js
+++ b/back/knex/stable/seeds/08_track_supervision.js
@@ -13,7 +13,8 @@ exports.seed = async function(knex) {
       supervisions.push({
         scheduled_range_supervision_id: id,
         track_id: track.id,
-        track_supervisor: 'present'
+        track_supervisor: 'present',
+        visitors: 0
       });
     });
   });

--- a/back/models/trackSupervision.js
+++ b/back/models/trackSupervision.js
@@ -12,7 +12,7 @@ const model = {
   /**
    * Create a new supervision event for track
    *
-   * @param {object} supVis - supervision properties, { scheduled_range_supervision_id, track_id, track_supervisor, notice? }
+   * @param {object} supVis - supervision properties, { scheduled_range_supervision_id, track_id, track_supervisor, visitors?, notice? }
    * @return {Promise<[{scheduled_range_supervision_id:number, track_id:number}]>} The combined key for track supervision range_supervision_id, track_id
    *
    * @example
@@ -23,6 +23,7 @@ const model = {
       scheduled_range_supervision_id: {},
       track_id: {},
       track_supervisor: {},
+      visitors: {},
       notice: {}
     };
 
@@ -51,8 +52,8 @@ const model = {
   /**
    * Get the supervisions matching a key.
    *
-   * @param {object} key - Identifying key, { scheduled_range_supervision_id?, track_id?, track_supervisor?, notice? }
-   * @param {object} fields - Attributes about the supervision to select { scheduled_range_supervision_id?, track_id?, track_supervisor?, notice? }
+   * @param {object} key - Identifying key, { scheduled_range_supervision_id?, track_id?, track_supervisor?, visitors?, notice? }
+   * @param {object} fields - Attributes about the supervision to select { scheduled_range_supervision_id?, track_id?, track_supervisor?, visitors?, notice? }
    * @return {Promise<object[]>} Supervisions that matched the key
    *
    * @example
@@ -69,7 +70,7 @@ const model = {
    * Update a supervision events' info.
    *
    * @param {object} current - The current identifying info of the supervision. { scheduled_range_supervision_id, track_id }
-   * @param {object} update - New information for the supervision { track_supervisor?, notice? }
+   * @param {object} update - New information for the supervision { track_supervisor?, visitors?, notice? }
    *
    * @return {Promise<number[]>} Count of rows updated
    *
@@ -77,7 +78,7 @@ const model = {
    * model.update({ scheduled_range_supervision_id:1, track_id:1 }, { track_supervisor: 'absent' })
    */
   update: async function updateSupervision(current, update) {
-    const supVis = _.pick(update, 'track_supervisor', 'notice');
+    const supVis = _.pick(update, 'track_supervisor', 'visitors', 'notice');
 
     const id = await model
       .read(current, ['scheduled_range_supervision_id', 'track_id'])

--- a/back/services/trackSupervision.js
+++ b/back/services/trackSupervision.js
@@ -20,7 +20,7 @@ const service = {
   /**
    * Get the supervisions matching a key.
    *
-   * @param {object} key - Identifying key, { scheduled_range_supervision_id?, track_id?, track_supervisor?, notice? }
+   * @param {object} key - Identifying key, { scheduled_range_supervision_id?, track_id?, track_supervisor?, visitors?, notice? }
    * @return {Promise<object[]>} Supervisions that matched the key
    *
    */

--- a/back/services/trackSupervision.js
+++ b/back/services/trackSupervision.js
@@ -9,7 +9,7 @@ const service = {
   /**
    * Create a new supervision.
    *
-   * @param {object} info - The properties of the new supervision { scheduled_range_supervision_id, track_id, track_supervisor, notice?}
+   * @param {object} info - The properties of the new supervision { scheduled_range_supervision_id, track_id, track_supervisor, visitors?, notice?}
    * @return {Promise<[{scheduled_range_supervision_id:number, track_id:number}]>} The combined key for track supervision range_supervision_id, track_id
    *
    */
@@ -25,14 +25,14 @@ const service = {
    *
    */
   read: async function readSupervision(key) {
-    return (await models.trackSupervision.read(_.pick(key, 'scheduled_range_supervision_id', 'track_id', 'track_supervisor', 'notice')));
+    return (await models.trackSupervision.read(_.pick(key, 'scheduled_range_supervision_id', 'track_id', 'track_supervisor', 'visitors', 'notice')));
   },
 
   /**
    * Update a supervision events' info.
    *
    * @param {object} current - The current identifying info of the supervision. { scheduled_range_supervision_id, track_id }
-   * @param {object} update - New information for the supervision { track_supervisor?, notice? }
+   * @param {object} update - New information for the supervision { track_supervisor?, visitors?, notice? }
    *
    * @return {Promise<number[]>} Count of rows updated
    *

--- a/back/validators/trackSupervision.js
+++ b/back/validators/trackSupervision.js
@@ -56,6 +56,13 @@ const fields = {
       .isLength({ min: 0, max: 255 })
       .withMessage('must be between 0 and 255 characters');
     return validatorAdditions(validator, opts);
+  },
+
+  visitors: function visitorValidation(requestObject, ...opts) {
+    const validator = requestObject('visitors')
+      .isInt()
+      .withMessage('must be an integer');
+    return validatorAdditions(validator, opts);
   }
 };
 
@@ -93,6 +100,7 @@ module.exports = {
     fields.scheduled_range_supervision_id(body, 'exists'),
     fields.track_id(body, 'exists'),
     fields.track_supervisor(body, 'exists'),
+    fields.visitors(body, 'optional'),
     fields.notice(body, 'optional'),
     handleValidationErrors,
     function storeCreationRequest(request, response, next) {
@@ -104,6 +112,7 @@ module.exports = {
     fields.scheduled_range_supervision_id(param, 'exists'),
     fields.track_id(param, 'exists'),
     fields.track_supervisor(body, 'optional'),
+    fields.visitors(body, 'optional'),
     fields.notice(body, 'optional'),
     handleValidationErrors,
     function storeUpdateRequest(request, response, next) {


### PR DESCRIPTION
Track-supervision now has a visitors integer attribute for tracking the number of visitors during someone's track supervision.

Usage:

For getting a specific track supervision you can use the "stock" read for track-supervision already found in the database; basically you need to get the two identifying ids (scheduleId, trackId) and call GET "api/track-supervision/:scheduleId/:trackId". This'll include the visitors under the object it returns.

Example:
axios.get("api/track-supervision/553/23")

For getting any number of days you can a new version of the daterange system: just determine the days you want to get and post them to the api/daterange/:begin/:end route. For each day you queried for the object will contain one "day" object from where you can find the visitors under day['tracks'][trackNumber]['scheduled']['visitors'].

Example:
axios.get("api/daterange/freeform/2020-01-01/2021-01-01")

For updating a single day you can use the "stock" update for track-supervision already found in the database; basically you need to pass an object with the visitors while calling PUT "api/track-supervision/:scheduleId/:trackId". This action will require an authorization header (config) with the token. NOTE: soon you will no longer need to add the authentication header as that'd be done with a cookie.

Example:
axios.put("api/track-supervision/553/23", {visitors: 23}, config)

No multitrack update is implemented. Please notify if one is required.