### PR TITLE
Bugfix statistics (maybe?)

### DIFF
--- a/front/src/tabletview/rangeofficer.js
+++ b/front/src/tabletview/rangeofficer.js
@@ -130,19 +130,17 @@ const TrackButtons = ({ track, scheduleId, tablet, fin, socket }) => {
     borderRadius: 30,
     width: 230,
   };
-  let text = tablet.Green[fin];
+
   const [buttonColor, setButtonColor] = useState(track.color);
-  const [textState, setTextState] = useState(tablet.Green[fin]);
-  const [supervision, setSupervision] = useState(text);
-  useEffect(() => {
-    if (track.trackSupervision === 'absent') {
-      text = tablet.White[fin];
-      setTextState(tablet.White[fin]);
-    } else if (track.trackSupervision === 'closed') {
-      text = tablet.Red[fin];
-      setTextState(tablet.Red[fin]);
-    }
-  }, []);
+
+  const supervisorState = track.scheduled.track_supervisor;
+  let supervisorStateTablet;
+  if (supervisorState === 'present') supervisorStateTablet = 'Green';
+  else if (supervisorState === 'closed') supervisorStateTablet = 'Red';
+  else supervisorStateTablet = 'White';
+
+  const [textState, setTextState] = useState(tablet[supervisorStateTablet][fin]);
+  const [supervision, setSupervision] = useState(supervisorState);
 
   socket.on('trackUpdate', (msg) => {
     if (msg.id === track.id) {


### PR DESCRIPTION
In the tablet view, when incrementing the number of visitors, if
the status of the range officer wasn't changed once (or multiple times)
the request for updating the visitor count for a range failed with
status 500 and thus no updates would go through.

This was due to the state of the supervision being initialized to "Paikalla". The backend has a check to see that the supervisor state is either "absent", "present" or "closed".

Fixed by initializing the state of the supervision to be what is fetched from the backend.