### PR TITLE
rewrite associations' getSupervisions functionality

### DIFF
--- a/back/controllers/rangeSupervision.js
+++ b/back/controllers/rangeSupervision.js
@@ -82,6 +82,20 @@ const controller = {
       .send(response.locals.queryResult);
   },
 
+  associationSupervisions: async function getAssociationSupervisions(request, response) {
+    if (response.locals.queryResult.length === 0) {
+      return response
+        .status(404)
+        .send({
+          error: 'Association has no supervisions'
+        });
+    }
+
+    return response
+      .status(200)
+      .send(response.locals.queryResult);
+  },
+
   feedback: async function sendFeedback(request, response) {
     const feedback = response.locals.query.feedback;
     const superusers = response.locals.superusers;

--- a/back/controllers/rangeSupervision.js
+++ b/back/controllers/rangeSupervision.js
@@ -83,7 +83,7 @@ const controller = {
   },
 
   associationSupervisions: async function getAssociationSupervisions(request, response) {
-    if (response.locals.queryResult.length === 0) {
+    if (!response.locals.queryResult) {
       return response
         .status(404)
         .send({

--- a/back/middlewares/rangeSupervision.js
+++ b/back/middlewares/rangeSupervision.js
@@ -41,6 +41,18 @@ const serviceCalls = {
     return next();
   },
 
+  associationSupervisions: async function getAssociationSupervisions(request, response, next) {
+    const query = response.locals.query;
+
+    try {
+      response.locals.queryResult = await services.rangeSupervision.associationSupervisions(query);
+    } catch (e) {
+      return next(e);
+    }
+
+    return next();
+  },
+  
   create: async function createSupervision(request, response, next) {
     const query = response.locals.query;
     let id;
@@ -124,6 +136,11 @@ exports.read = [validators.rangeSupervision.read, serviceCalls.read];
 exports.userSupervisions = [
   validators.rangeSupervision.userSupervisions,
   serviceCalls.userSupervisions,
+];
+
+exports.associationSupervisions = [
+  validators.rangeSupervision.associationSupervisions,
+  serviceCalls.associationSupervisions,
 ];
 
 exports.create = [validators.rangeSupervision.create, serviceCalls.create];

--- a/back/models/rangeSupervision.js
+++ b/back/models/rangeSupervision.js
@@ -93,6 +93,30 @@ const model = {
   },
 
   /**
+   * Get the supervisions matching an association id.
+   *
+   * @param {object} key - Identifying association key, { association }
+   * @param {object} fields - Attributes about the supervision to select (currently selects all but leaving the option to make it modular in the future)
+   * @return {Promise<object[]>} Supervisions that matched the association id
+   *
+   * @example
+   * model.associationSupervisions({ association: 1 }, [])
+   */
+  associationSupervisions: async function getAssociationSupervisions(key, fields) {
+    const currentDate = new Date();
+    
+    return await knex
+      .from('scheduled_range_supervision as srs')
+      .leftJoin('range_supervision as rs', 'srs.id', 'rs.scheduled_range_supervision_id')
+      .leftJoin('range_reservation as rr', 'srs.range_reservation_id', 'rr.id')
+      .where('srs.association_id', key['association']) // filter by association id
+      .andWhere('rr.available', true)
+      .andWhere('rr.date', '>=', currentDate)           // only future reservations
+      .select(fields)                                   // empty array falls back to '*'
+      .orderBy('rr.date', 'asc');
+  },
+
+  /**
    * Update a supervision events' info.
    *
    * @param {object} current - The current identifying info of the supervision. { scheduled_range_supervision_id }

--- a/back/routes.js
+++ b/back/routes.js
@@ -164,6 +164,13 @@ router
   );
 
 router
+  .route('/range-supervision/association/:association')
+  .get(
+    middlewares.rangeSupervision.associationSupervisions,
+    controllers.rangeSupervision.associationSupervisions
+  );
+
+router
   .route('/reservation')
   .get(controllers.reservation.read)
   .post(

--- a/back/services/rangeSupervision.js
+++ b/back/services/rangeSupervision.js
@@ -41,6 +41,10 @@ const service = {
     return (await models.rangeSupervision.userSupervisions(_.pick(key, 'id', 'name', 'role', 'phone', 'email'), fields));
   },
 
+  associationSupervisions: async function getAssociationSupervisions(key, fields) {
+    return (await models.rangeSupervision.associationSupervisions(_.pick(key, 'association'), fields));
+  },
+
   /**
    * Update a supervision events' info.
    *

--- a/back/validators/rangeSupervision.js
+++ b/back/validators/rangeSupervision.js
@@ -142,6 +142,14 @@ module.exports = {
       return next();
     },
   ],
+  associationSupervisions: [
+    fields.association(param, 'exists'),
+    handleValidationErrors,
+    function storeID(request, response, next) {
+      response.locals.query = matchedData(request, { locations: ['params'] });
+      return next();
+    },
+  ],
   feedback: [
     fields.feedback(body, 'exists'),
     fields.user(body, 'exists'),


### PR DESCRIPTION
Listing association's supervisions was slow because first front end made an api call to get a list of existing supervisions for association and then it proceeded to make two separate new calls for each supervision. So all in all the number of api calls was `number of supervisions x 2 + 1`  when now the same functionality is done with only 1 request.