### PR TITLE
Vo docker paths

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine as base
 
 WORKDIR /app
-COPY package*.json /app
+COPY package*.json /app/
 EXPOSE 3000
 
 FROM base as dev


### PR DESCRIPTION
Fixed backend Dockerfile COPY path to comply with Debian Linux syntax for folder paths

added '/' to the end of the path