### PR TITLE
Fixed issues with adding association and rangeofficer users

### DIFF
--- a/back/services/user.js
+++ b/back/services/user.js
@@ -64,7 +64,7 @@ const service = {
     const digest = await hash(info.password);
     delete info.password;
     info.digest = digest;
-    return (await models.user.create(info)).pop();
+    return await models.user.create(info);
   },
 
   /**


### PR DESCRIPTION
fix: ensure createUser returns integer ID for all user roles

- Modified createUser function to consistently return integer ID
- Adjusted ID extraction for association and rangeofficer roles
- Simplified transaction handling for user creation

Problem:

When creating associations or rangeofficers, the id returned by database operation would become { id: { user_id: 19 } } or { id: { rangeofficer_id: 19 } } instead of { id: 19 }