### PR TITLE
ETA won't be shown in weekview if rangestatus is present

### DIFF
--- a/front/src/scheduling/Scheduling.js
+++ b/front/src/scheduling/Scheduling.js
@@ -561,16 +561,12 @@ function Scheduling(props) {
     const fin = localStorage.getItem('language');
     const items = [];
 
-    for (const key in tracks) {
-      const trackName = tracks[key].name
-      const splittedTrackName = trackName.split(' ');
-      const trackNumber = splittedTrackName[2];
-      
+    for (const key in tracks) {   
       items.push(
         <React.Fragment key = {key}>
           <Box className={`trackBox ${trackStates[tracks[key].id] === 'present' ? 'track-open' : 'track-closed'}`}>
             <FormControl component="fieldset" style={{padding:'5px'}}>
-              <FormLabel component="legend">{`${sched.ShootingTrack[fin]} ${trackNumber}`}</FormLabel>
+              <FormLabel component="legend">{tracks[key].name}</FormLabel>
               <div className="trackSwitchRow">
                 <div>{sched.TrackOpen[fin]}</div>
                 <CustomSwitch

--- a/front/src/weekview/Weekview.js
+++ b/front/src/weekview/Weekview.js
@@ -350,7 +350,7 @@ const Weekview = (props) => {
         });
       }
 
-      if (paivat[j].arriving_at !== null) {
+      if (paivat[j].arriving_at !== null && rataStatus !== 'present') {
         info = true;
         arrivalTime = moment(paivat[j].arriving_at, 'HH:mm:ss').format('HH:mm');
       }


### PR DESCRIPTION
- Added condition that checks if the rangeStatus is present -> if true ETA won't be shown in weekview


- fixed also the undefined issue related to the names of tracks in schedules view
-> It translated the name, but it won't work if the name is something else than Shooting track, so I deleted it. Now it will print the name as it is in the database