### PR TITLE
Updated the workflow to build images

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,11 +1,10 @@
-name: Build and push Docker image
+name: Publish Docker image
+description: 'Publish docker image'
 
 on:
-  release:
-    types: [released]
   push:
-    tags:
-    - "dev-*"
+    branches: [master, 'v**-develop', '*']
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -18,23 +17,29 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
+
+      - name: Build and push container
+        uses: docker/build-push-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
+          context: ./
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -3,7 +3,7 @@ description: 'Publish docker image'
 
 on:
   push:
-    branches: [master, 'v**-develop', '*']
+    branches: [master, 'v**-develop']
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
- Updated docker image build workflow to use newer version of relevant workflows
- Changed build triggers to be pushing to either a `v*-develop` brach or `main`

This allows using `ghcr.io/tasera-ry/tss:master` as the image on production setups, instead of building the container locally. This should reduce hassle in the long run.

#### Examples:

##### docker run
```bash
$ docker run ghcr.io/tasera-ry/tss:master
```

##### docker compose
```yaml
image: ghcr.io/tasera-ry/tss:master
```
