### PR TITLE
Email fixes

### DIFF
--- a/back/controllers/emailSettings.js
+++ b/back/controllers/emailSettings.js
@@ -24,6 +24,8 @@ const controller = {
   },
   sendPendingEmails: async function sendPendingEmails(request, response) {
     const result = await sendPending();
+    console.log("Kalle: result", result)
+    if( !result || !result.length ) return response.status(404).send({ success: false, error: result.message });
     if (!result[0].success) {
       console.error("sendPendingEmails error:", error);
       return response.status(500).send({ success: false, error: error.message });

--- a/back/controllers/emailSettings.js
+++ b/back/controllers/emailSettings.js
@@ -24,7 +24,6 @@ const controller = {
   },
   sendPendingEmails: async function sendPendingEmails(request, response) {
     const result = await sendPending();
-    console.log("Kalle: result", result)
     if( !result || !result.length ) return response.status(404).send({ success: false, error: result.message });
     if (!result[0].success) {
       console.error("sendPendingEmails error:", error);

--- a/back/controllers/rangeSupervision.js
+++ b/back/controllers/rangeSupervision.js
@@ -85,7 +85,6 @@ const controller = {
 
   create: async function createSupervision(request, response) {
     try {
-      if (!response.req.body.association) return;
       const scheduleId = response.locals.id;
       email('assigned', response.req.body.association, { scheduleId: scheduleId });
     } catch (error) {
@@ -100,11 +99,12 @@ const controller = {
     //updates.range_supervisor returns "absent" if association has not been assigned. it returns "not confirmed" is association is assigned.
     //if - checks if association is assigned and only sends email if it is set. otherwise it would send email aswell when association is taken off.
     try {
-      
+
       const scheduleId = response.locals.id.scheduled_range_supervision_id;
-      if (response.locals.updates.range_supervisor === 'not confirmed' && response.locals.updates.association){
-        email('update', response.locals.updates.association, { scheduleId: scheduleId });
-      }
+      // Association was assigned supervision
+      // if (response.locals.updates && response.locals.updates.range_supervisor === 'not confirmed' && response.locals.updates.association){
+        // email('assigned', response.locals.updates.association, { scheduleId: scheduleId });
+      // }
 
       if (response.locals.updates.range_supervisor === 'absent' && response.locals.user.name) {
         const superusers = response.locals.superusers;

--- a/back/controllers/reservation.js
+++ b/back/controllers/reservation.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { email } = require('../mailer');
 const root = path.join(__dirname, '..');
 const middlewares = require(path.join(root, 'middlewares'));
 const validators = require(path.join(root, 'validators'));
@@ -30,12 +31,29 @@ async function readReservationStrict(request, response) {
 }
 
 async function updateReservation(request, response) {
+  console.log("Kalle: request", request.body)
+  if( request.body && request.body.supervisor ) {
+    const scheduleId = request.body.scheduleId ? {scheduleId: request.body.scheduleId} : undefined;
+    // send update email to supervisor associations
+    if( request.body.originalSupervisor && request.body.originalSupervisor !== request.body.supervisor ) {
+      // notify new supervisor about assigned supervision
+      email('assigned', request.body.supervisor, scheduleId)
+      // notify old supervisor that their supervision changed. Here a new email type like "supervision cancelled" could be handy
+      // but we have no time to implement it.
+      email('update', request.body.originalSupervisor, scheduleId)
+    } else {
+      // if supervisor was not changed
+      email('update', request.body.supervisor, scheduleId)
+    }
+  }
   return response
     .status(204)
     .send();
 }
 
 async function deleteReservation(request, response) {
+  console.log("Kalle: DELETE request", request.body)
+
   if(response.locals.queryResult === 0) {
     return response
       .status(404)

--- a/back/controllers/reservation.js
+++ b/back/controllers/reservation.js
@@ -31,7 +31,6 @@ async function readReservationStrict(request, response) {
 }
 
 async function updateReservation(request, response) {
-  console.log("Kalle: request", request.body)
   if( request.body && request.body.supervisor ) {
     const scheduleId = request.body.scheduleId ? {scheduleId: request.body.scheduleId} : undefined;
     // send update email to supervisor associations
@@ -52,7 +51,6 @@ async function updateReservation(request, response) {
 }
 
 async function deleteReservation(request, response) {
-  console.log("Kalle: DELETE request", request.body)
 
   if(response.locals.queryResult === 0) {
     return response

--- a/back/knex/development/seeds/02_users.js
+++ b/back/knex/development/seeds/02_users.js
@@ -28,7 +28,7 @@ exports.seed = async function (knex) {
 			password: '5Effie38',
 			digest: '$2a$10$oE0o638BBP/SkL2MQ0jEQeIxh6iKTkLoGaq/Cv6PuEzgeoqZTW4.e',
 			phone: '905-680-0458',
-			email: 'kalnyman77@gmail.com', // Kalle: muuta takaisin DevAssociation@email.com
+			email: 'DevAssociation@email.com',
 			role: 'association'
 		},
 		{

--- a/back/knex/development/seeds/02_users.js
+++ b/back/knex/development/seeds/02_users.js
@@ -28,7 +28,7 @@ exports.seed = async function (knex) {
 			password: '5Effie38',
 			digest: '$2a$10$oE0o638BBP/SkL2MQ0jEQeIxh6iKTkLoGaq/Cv6PuEzgeoqZTW4.e',
 			phone: '905-680-0458',
-			email: 'DevAssociation@email.com',
+			email: 'kalnyman77@gmail.com', // Kalle: muuta takaisin DevAssociation@email.com
 			role: 'association'
 		},
 		{

--- a/back/knex/development/seeds/09_settings.js
+++ b/back/knex/development/seeds/09_settings.js
@@ -14,13 +14,13 @@ exports.seed = function(knex) {
     shouldSend: "true",
     shouldQueue: "false",
     sendPendingTime: String(new Date(2024, 1, 1, 21, 17)),
-    assignedMsg: '',
-    updateMsg: '',
-    reminderMsg: 'reminder',
-    declineMsg: '',
-    feedbackMsg: '',
-    resetpassMsg: '',
-    collageMsg: ''
+    collageMsg: '{assigned} - Annettujen vuorojen määrä \n {update} - Muutettujen vuorojen määrä', // Kalle: not sure if works
+    assignedMsg: 'Hei, yhteisöllenne on aikataulutettu uusi(a) päävalvojavuoro(ja). Terveisin Tampereen Seudun Ampumaratayhdistys ry.',  // Kalle: not sure if works
+    updateMsg: 'Hei, teille annettua päävalvojavuoroa on muutettu. Käythän tarkistamassa vuoronne. Terveisin Tampereen Seudun Ampumaratayhdistys ry.',
+    reminderMsg: 'Hei, ette ole varmistaneet viikon päästä alkavaa päävalvojavuoroanne. Käykää mahdollisimman pian varmistamassa vuoronne. Terveisin Tampereen Seudun Ampumaratayhdistys ry.',
+    declineMsg: 'Valvontavuorosta kieltäydytty Valvoja: {user} Päivämäärä: {date} ',  // Kalle: not sure if works
+    feedbackMsg: 'Palaute vastaanotettu. Valvoja: {user} Palaute: {feedback} ', // Kalle: not sure if works
+    resetpassMsg: 'Olet pyytänyt salasanasi resetointia. Jos olet saanut tämän viestin vahingossa tai jos et ole tilannut salasanan resetointia TSS-sivulta, voit jättää tämän viestin huomiotta. \n Voit resetoida Tasera-salasanasi tästä linkistä: https://tss.tasera.fi/#/renew-password/{token} \n Terveisin, TASERA ry',  // Kalle: not sure if works
   };
 
   return knex('settings').del()

--- a/back/knex/development/seeds/09_settings.js
+++ b/back/knex/development/seeds/09_settings.js
@@ -14,13 +14,13 @@ exports.seed = function(knex) {
     shouldSend: "true",
     shouldQueue: "false",
     sendPendingTime: String(new Date(2024, 1, 1, 21, 17)),
-    collageMsg: '{assigned} - Annettujen vuorojen määrä \n {update} - Muutettujen vuorojen määrä', // Kalle: not sure if works
-    assignedMsg: 'Hei, yhteisöllenne on aikataulutettu uusi(a) päävalvojavuoro(ja). Terveisin Tampereen Seudun Ampumaratayhdistys ry.',  // Kalle: not sure if works
+    collageMsg: '{assigned} - Annettujen vuorojen määrä \n {update} - Muutettujen vuorojen määrä',
+    assignedMsg: 'Hei, yhteisöllenne on aikataulutettu uusi(a) päävalvojavuoro(ja). Terveisin Tampereen Seudun Ampumaratayhdistys ry.', 
     updateMsg: 'Hei, teille annettua päävalvojavuoroa on muutettu. Käythän tarkistamassa vuoronne. Terveisin Tampereen Seudun Ampumaratayhdistys ry.',
     reminderMsg: 'Hei, ette ole varmistaneet viikon päästä alkavaa päävalvojavuoroanne. Käykää mahdollisimman pian varmistamassa vuoronne. Terveisin Tampereen Seudun Ampumaratayhdistys ry.',
-    declineMsg: 'Valvontavuorosta kieltäydytty Valvoja: {user} Päivämäärä: {date} ',  // Kalle: not sure if works
-    feedbackMsg: 'Palaute vastaanotettu. Valvoja: {user} Palaute: {feedback} ', // Kalle: not sure if works
-    resetpassMsg: 'Olet pyytänyt salasanasi resetointia. Jos olet saanut tämän viestin vahingossa tai jos et ole tilannut salasanan resetointia TSS-sivulta, voit jättää tämän viestin huomiotta. \n Voit resetoida Tasera-salasanasi tästä linkistä: https://tss.tasera.fi/#/renew-password/{token} \n Terveisin, TASERA ry',  // Kalle: not sure if works
+    declineMsg: 'Valvontavuorosta kieltäydytty Valvoja: {user} Päivämäärä: {date} ', 
+    feedbackMsg: 'Palaute vastaanotettu. Valvoja: {user} Palaute: {feedback} ',
+    resetpassMsg: 'Olet pyytänyt salasanasi resetointia. Jos olet saanut tämän viestin vahingossa tai jos et ole tilannut salasanan resetointia TSS-sivulta, voit jättää tämän viestin huomiotta. \n Voit resetoida Tasera-salasanasi tästä linkistä: https://tss.tasera.fi/#/renew-password/{token} \n Terveisin, TASERA ry', 
   };
 
   return knex('settings').del()

--- a/back/knex/development/seeds/09_settings.js
+++ b/back/knex/development/seeds/09_settings.js
@@ -4,7 +4,7 @@ exports.seed = function(knex) {
   const emailSettings = {
     sender: "noreply@tasera.fi",
     user: "ratavuorot@tasera.fi",
-    pass: "mbpw svpd pcgu waey",
+    pass: "",
     // user: process.env.EMAIL_USER,
     // pass: process.env.EMAIL_PASSWORD,
     host: "smtp.gmail.com",

--- a/back/mailer.js
+++ b/back/mailer.js
@@ -27,15 +27,21 @@ const email = async (messageType, key, opts) => {
   }
   switch (messageType) {
     case 'reminder':
-      // always send reminders
+      // always send reminders, no need to queue
       sendEmail(getText(messageType, opts, emailSettings), emailAddress, emailSettings);
       break;
     default:
-      if (emailSettings.shouldQueue === 'true') {
+      // I have no idea what this scheduleId is supposed to be, but we must include it when saving pending emails.
+      if (emailSettings.shouldQueue === 'true' && opts && opts.scheduleId) {
+        console.log("Kalle: add email to pending emails", messageType)
+        console.log("Kalle: add email to pending emails", opts)
+        console.log("Kalle: add email to pending emails", emailAddress)
         // add to pending emails
         services.pendingEmails.add(messageType, key, opts.scheduleId);
       } else { 
         // send directly
+        console.log("Kalle: send directly", messageType)
+        console.log("Kalle: send directly", emailAddress)
         sendEmail(getText(messageType, opts, emailSettings), emailAddress, emailSettings);
       }
   }
@@ -55,8 +61,6 @@ const sendPending = async () => {
   try {
     const emailSettings = await services.emailSettings.read();
     const pending = await services.pendingEmails.read();
-
-    console.log("Kalle: pending", pending)
 
     if (!pending || pending.length === 0) {
       return { success: false, message: 'No messages to send.' };
@@ -125,6 +129,7 @@ const sendPending = async () => {
 const getText = (message, opts, emailSettings) => {
   let text = message;
   let allowedVars = {};
+  console.log("Mailer: getText message:", message)
   switch (message) {
     case 'assigned':
       text = emailSettings.assignedMsg;
@@ -155,6 +160,7 @@ const getText = (message, opts, emailSettings) => {
       allowedVars['{assigned}'] = opts.assignedCount;
       break;
   }
+  console.log("Mailer: getText text:", text)
   // Insert dynamic values into the message
   Object.keys(allowedVars).forEach(token => {
     text = text.replace(new RegExp(token, 'g'), allowedVars[token]);

--- a/back/mailer.js
+++ b/back/mailer.js
@@ -56,8 +56,10 @@ const sendPending = async () => {
     const emailSettings = await services.emailSettings.read();
     const pending = await services.pendingEmails.read();
 
-    if (pending.length === 0) {
-      return { success: true, message: 'No messages to send.' };
+    console.log("Kalle: pending", pending)
+
+    if (!pending || pending.length === 0) {
+      return { success: false, message: 'No messages to send.' };
     }
 
     // Print pending emails to console

--- a/back/mailer.js
+++ b/back/mailer.js
@@ -33,15 +33,14 @@ const email = async (messageType, key, opts) => {
     default:
       // I have no idea what this scheduleId is supposed to be, but we must include it when saving pending emails.
       if (emailSettings.shouldQueue === 'true' && opts && opts.scheduleId) {
-        console.log("Kalle: add email to pending emails", messageType)
-        console.log("Kalle: add email to pending emails", opts)
-        console.log("Kalle: add email to pending emails", emailAddress)
+        console.log("email: add email to pending emails", messageType)
+        console.log("email: add email to pending emails", emailAddress)
         // add to pending emails
         services.pendingEmails.add(messageType, key, opts.scheduleId);
       } else { 
         // send directly
-        console.log("Kalle: send directly", messageType)
-        console.log("Kalle: send directly", emailAddress)
+        console.log("email: send email directly", messageType)
+        console.log("email: send email directly", emailAddress)
         sendEmail(getText(messageType, opts, emailSettings), emailAddress, emailSettings);
       }
   }

--- a/back/models/emailSettings.js
+++ b/back/models/emailSettings.js
@@ -19,6 +19,7 @@ const model = {
       .orWhere({ setting_name: 'email_shouldsend' })
       .orWhere({ setting_name: 'email_assigned_msg' })
       .orWhere({ setting_name: 'email_update_msg' })
+      .orWhere({ setting_name: 'email_cc' })
       .orWhere({ setting_name: 'email_reminder_msg' })
       .orWhere({ setting_name: 'email_decline_msg' })
       .orWhere({ setting_name: 'email_feedback_msg' })

--- a/front/src/EmailSettings/EmailSettings.js
+++ b/front/src/EmailSettings/EmailSettings.js
@@ -120,8 +120,6 @@ const EmailSettings = () => {
             filteredData[key] = data[key];
           else filteredData[key] = settings[key];
         });
-        console.log("Kalle: fetch settings", data)
-        console.log("Kalle: filteredData", filteredData)
         setSettings(filteredData);
       });
   };
@@ -200,7 +198,6 @@ const EmailSettings = () => {
       setNotification({ open: true, message: emailSettings.ccError[lang], type: 'error' });
       return;
     }
-    console.log("Kalle: settings.cc", settings.cc)
 
     setPendingSave(true);
 

--- a/front/src/EmailSettings/EmailSettings.js
+++ b/front/src/EmailSettings/EmailSettings.js
@@ -120,6 +120,8 @@ const EmailSettings = () => {
             filteredData[key] = data[key];
           else filteredData[key] = settings[key];
         });
+        console.log("Kalle: fetch settings", data)
+        console.log("Kalle: filteredData", filteredData)
         setSettings(filteredData);
       });
   };
@@ -132,7 +134,11 @@ const EmailSettings = () => {
         const result = await res.json();
         setPendingSend(false);
         // Sending pending emails failed
-        if (res.status !== 200) {
+        if(res.status === 404) {
+          // no pending emails to send
+          setNotification({ open: true, message: emailSettings.pendingEmpty[lang], type: 'success' });
+        }
+        else if (res.status !== 200) {
           setNotification({ open: true, message: emailSettings.pendingError[lang], type: 'error' });
         }
         // Sending pending emails was successful
@@ -194,6 +200,7 @@ const EmailSettings = () => {
       setNotification({ open: true, message: emailSettings.ccError[lang], type: 'error' });
       return;
     }
+    console.log("Kalle: settings.cc", settings.cc)
 
     setPendingSave(true);
 

--- a/front/src/scheduling/Scheduling.js
+++ b/front/src/scheduling/Scheduling.js
@@ -679,11 +679,12 @@ function Scheduling(props) {
         scheduledRangeSupervisionMethod = 'PUT';
         scheduledRangeSupervisionPath = `/${srsId}`;
       } else scheduledRangeSupervisionMethod = 'POST';
-
       let params = {
         range_id: rangeId,
         available: available,
         supervisor: rangeSupervisorId,
+        originalSupervisor: rangeSupervisorOriginal,
+        scheduleId: srsId
       };
 
       if (reservationMethod === 'POST') {


### PR DESCRIPTION
Korjattu kaatuminen, jos ei pending-viestejä.

**Toimivat TSS sähköposti-featuret:**
- valvontaa muokattu -> valvoja saa "vuoro päivitetty" sähköpostia
- jos vaihtaa valvojaa valmiiksi avatussa keskuksessa:
	- uusi valvoja saa "vuoro annettu" sähköpostia
	- vanha valvoja saa "vuoro päivitetty" sähköpostia
- ajan asettaminen
- varmistamattoman vuoron muistutuksen + pending-viestien aikataulutettu lähetys
- cc-osoite korjattu
- palauteesta lähtee sähköposti superuserille

**Vielä testaamatta / toteuttamatta:**
- keskuksen avaaminen "nollasta"
	- "vuoro annettu" sähköpostin pitäisi lähteä, mutta ei voi testata ennen Oskarin bugifiksiä
- salasanan vaihto
- vuorosta kieltäydytty
- kootut varausten muutokset
