### PR TITLE
Fix/seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Program for management and scheduling of Tasera managed shooting ranges in Pirka
 #### Note!
 Using Docker this way may cause unexpected *"works on my machine"* type issues. **Deleting containers, images, volumes** and `node_modules` folder usually fix these issues, but a dedicated enviroment would be preferable.
 
+Seed data for dev environment works **only** if the current date is between startDate and endDate in back/config/config.js.
+
 ### Production test
 
 This assumes a database already exists and can be mounted. The path and credentials are defined in `test_env_variables.env`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Program for management and scheduling of Tasera managed shooting ranges in Pirka
 #### Note!
 Using Docker this way may cause unexpected *"works on my machine"* type issues. **Deleting containers, images, volumes** and `node_modules` folder usually fix these issues, but a dedicated enviroment would be preferable.
 
-Seed data for dev environment works **only** if the current date is between startDate and endDate in back/config/config.js.
+Config for seed data is set plus minus one year in back/config/config.js 
 
 ### Production test
 

--- a/back/config/config.js
+++ b/back/config/config.js
@@ -21,8 +21,8 @@ const config = {
     users: 10,
     ranges: 1,
     tracks: 7,
-    startDate: '2025-01-01',
-    endDate: '2029-12-31',
+    startDate: new Date().toISOString().slice(0,10),
+    endDate: new Date(Date.now() + 365 * 24*60*60*1000).toISOString().slice(0,10),
     // chunkSize = how many rows are inserted in a single insertion, larger
     // chunk size equals faster insertions, but a value that is too high causes
     // errors. In case of errors, try dropping the factor down.

--- a/back/config/config.js
+++ b/back/config/config.js
@@ -21,10 +21,8 @@ const config = {
     users: 10,
     ranges: 1,
     tracks: 7,
-    // TODO fix dates to use for example start:(current date - 60 days) - end:(current date + 90 days)
-    // TODO document this seed data date range and that dev only works fo this date range in README
-    startDate: '2025-04-01',
-    endDate: '2025-12-31',
+    startDate: '2025-01-01',
+    endDate: '2029-12-31',
     // chunkSize = how many rows are inserted in a single insertion, larger
     // chunk size equals faster insertions, but a value that is too high causes
     // errors. In case of errors, try dropping the factor down.

--- a/back/config/config.js
+++ b/back/config/config.js
@@ -21,7 +21,7 @@ const config = {
     users: 10,
     ranges: 1,
     tracks: 7,
-    startDate: new Date().toISOString().slice(0,10),
+    startDate: new Date(Date.now() - 365 * 24*60*60*1000).toISOString().slice(0,10),
     endDate: new Date(Date.now() + 365 * 24*60*60*1000).toISOString().slice(0,10),
     // chunkSize = how many rows are inserted in a single insertion, larger
     // chunk size equals faster insertions, but a value that is too high causes


### PR DESCRIPTION
Changed startDate and endDate in back/config/config.js to cover five years. Updated README by adding instructions for seed data setup to development section.